### PR TITLE
Support manually configured resolv.conf

### DIFF
--- a/assets/GWSL_helper.sh
+++ b/assets/GWSL_helper.sh
@@ -41,19 +41,19 @@ then
 		then
 			# Configure Fish
 			sed -i.bak '/DISPLAY /d' ~/.config/fish/config.fish
-			echo "set -gx DISPLAY (cat /etc/resolv.conf | grep nameserver | awk '{print \$2; exit;}'):0.0 #GWSL" >> ~/.config/fish/config.fish
+			echo "set -gx DISPLAY (ip -4 route show default | cut -d' ' -f3):0.0 #GWSL" >> ~/.config/fish/config.fish
 		elif [ $wsl_shell == "zsh" ]
 		then
 			# Configure Zsh
 			sed -i.bak '/DISPLAY=/d' ~/.zshrc
-			echo "export DISPLAY=\$(cat /etc/resolv.conf | grep nameserver | awk '{print \$2; exit;}'):0.0 #GWSL" >> ~/.zshrc
+			echo "export DISPLAY=\$(ip -4 route show default | cut -d' ' -f3):0.0 #GWSL" >> ~/.zshrc
 		elif [ $wsl_shell == "bash" ]
 		then
 			# Configure Bash
 			sed -i.bak '/DISPLAY=/d' ~/.profile
-			echo "export DISPLAY=\$(cat /etc/resolv.conf | grep nameserver | awk '{print \$2; exit;}'):0.0 #GWSL" >> ~/.profile
+			echo "export DISPLAY=\$(ip -4 route show default | cut -d' ' -f3):0.0 #GWSL" >> ~/.profile
 			sed -i.bak '/DISPLAY=/d' ~/.bashrc
-			echo "export DISPLAY=\$(cat /etc/resolv.conf | grep nameserver | awk '{print \$2; exit;}'):0.0 #GWSL" >> ~/.bashrc
+			echo "export DISPLAY=\$(ip -4 route show default | cut -d' ' -f3):0.0 #GWSL" >> ~/.bashrc
 		fi
 	fi
 
@@ -91,19 +91,19 @@ then
 		then
 			# Configure Fish
 			sed -i.bak '/PULSE_SERVER /d' ~/.config/fish/config.fish
-			echo "set -gx PULSE_SERVER tcp:(cat /etc/resolv.conf | grep nameserver | awk '{print \$2; exit;}') #GWSL" >> ~/.config/fish/config.fish
+			echo "set -gx PULSE_SERVER tcp:(ip -4 route show default | cut -d' ' -f3) #GWSL" >> ~/.config/fish/config.fish
 		elif [ $wsl_shell == "zsh" ]
 		then
 			# Configure Zsh
 			sed -i.bak '/PULSE_SERVER=/d' ~/.zshrc
-			echo "export PULSE_SERVER=tcp:\$(cat /etc/resolv.conf | grep nameserver | awk '{print \$2; exit;}') #GWSL" >> ~/.zshrc
+			echo "export PULSE_SERVER=tcp:\$(ip -4 route show default | cut -d' ' -f3) #GWSL" >> ~/.zshrc
 		elif [ $wsl_shell == "bash" ]
 		then
 			# Configure Bash
 			sed -i.bak '/PULSE_SERVER=/d' ~/.profile
-			echo "export PULSE_SERVER=tcp:\$(cat /etc/resolv.conf | grep nameserver | awk '{print \$2; exit;}') #GWSL" >> ~/.profile
+			echo "export PULSE_SERVER=tcp:\$(ip -4 route show default | cut -d' ' -f3) #GWSL" >> ~/.profile
 			sed -i.bak '/PULSE_SERVER=/d' ~/.bashrc
-			echo "export PULSE_SERVER=tcp:\$(cat /etc/resolv.conf | grep nameserver | awk '{print \$2; exit;}') #GWSL" >> ~/.bashrc
+			echo "export PULSE_SERVER=tcp:\$(ip -4 route show default | cut -d' ' -f3) #GWSL" >> ~/.bashrc
 		fi
 	fi
 

--- a/manager.py
+++ b/manager.py
@@ -778,7 +778,7 @@ def get_ip(machine):
     :return:
     """
     #print("get_ip")
-    cmd = "wsl.exe -d " + str(machine) + ' ' + "/bin/sh -c " + '"' + """(cat /etc/resolv.conf | grep nameserver | awk '{print $2; exit;}')""" + '"'
+    cmd = "wsl.exe -d " + str(machine) + ' ' + "/bin/sh -c " + '"' + """(ip -4 route show default | cut -d' ' -f3)""" + '"'
 
     
     #print(cmd)
@@ -794,7 +794,7 @@ def get_ip(machine):
     try:
         ipa = ipaddress.ip_address(result)
     except:
-        cmd = "wsl.exe -d " + str(machine) + ' ' + "/bin/sh -c " + '"' + """echo $(cat /etc/resolv.conf | grep nameserver | awk '{print $2; exit;}')""" + '"'
+        cmd = "wsl.exe -d " + str(machine) + ' ' + "/bin/sh -c " + '"' + """echo $(ip -4 route show default | cut -d' ' -f3)""" + '"'
         result = os.popen(cmd).readlines()[0]
         #result = "localhost"
     
@@ -802,7 +802,7 @@ def get_ip(machine):
     #print("ipa", ipa, "ipd")
 
     
-    #result = runo3(machine, """echo $(cat /etc/resolv.conf | grep nameserver | awk '{print $2; exit;}')""")
+    #result = runo3(machine, """echo $(ip -4 route show default | cut -d' ' -f3)""")
     #print("ip", result, "done")
     return result  # [0][:-1]
 


### PR DESCRIPTION
GWSL currently relies on WSL automatically setting the default gateway IP in `/etc/resolv.conf`. `/etc/resolv.conf` cannot be relied upon in cases where a user has set `network.generateResolvConf = false` in their `/etc/wsl.conf`, in order to override their `/etc/resolv.conf` (eg. https://github.com/microsoft/WSL/issues/5336).

This PR uses `ip route show default` to get the default gateway IP instead.

Possibly resolve #97 too.