### PR TITLE
fixed: when non ASCII character in .profile on CJK Windows

### DIFF
--- a/wsl_tools.py
+++ b/wsl_tools.py
@@ -1,6 +1,4 @@
-import os
 import subprocess
-import time
 
 script = None
 
@@ -18,7 +16,7 @@ def pat_con(path):
 
 def get_themes(machine):
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + '" listthemes'
-    read = os.popen(cmd).read()
+    read = subprocess.check_output(cmd).decode("UTF-8")
     read = read.split(":theme:")
     read[:] = (value for value in read if value != "\n")
     read[:] = (value for value in read if value != "\n\n")
@@ -63,7 +61,7 @@ class WSLApp: #Credit to @sanzoghenzo on github. I did some adapting
 def get_apps(machine, logger=None):
     #first make sure the machine is booted. Scanning should do the trick
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + '" listapps'
-    read = os.popen(cmd).read()
+    read = subprocess.check_output(cmd).decode("UTF-8")
     apps = read.splitlines()
     #apps.remove("")
     """
@@ -97,7 +95,7 @@ def get_apps_old(machine):
     # except:
     #    pass
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + '" listappsold'
-    read = os.popen(cmd).read()
+    read = subprocess.check_output(cmd).decode("UTF-8")
     # print("copy")
     # cmd2 = 'wsl.exe -d ' + str(machine) + ' cp ~/.scanapps ' + str(pat_con(script[:-15]))
     # subprocess.getoutput(cmd2)
@@ -144,7 +142,7 @@ def get_apps_old(machine):
 
 def export_v(machine, name, value, shell="bash"):
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + f'" export-v {name} {value} {shell}'
-    print(os.popen(cmd).read()[:-1])
+    print(subprocess.check_output(cmd).decode("UTF-8")[:-1])
 
 def gtk(machine, scale, shell="bash"):
     export_v(machine, "GDK_SCALE", scale, shell=shell)
@@ -164,7 +162,7 @@ def qt(machine, scale, shell="bash"):
 
 def dbus(machine):
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + '" dbus'
-    print(os.popen(cmd).read()[:-1])
+    print(subprocess.check_output(cmd).decode("UTF-8")[:-1])
 
 
 
@@ -173,19 +171,20 @@ def dbus(machine):
 def export(machine, version, shell="bash"):
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + '" export-d ' + str(version) + " " + shell
     print(cmd)
-    print(os.popen(cmd).read()[:-1])
+    print(subprocess.check_output(cmd).decode("UTF-8")[:-1])
 
 def export_audio(machine, version, shell="bash"):
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + '" export-a ' + str(version) + " " + shell
     print(cmd)
-    print(os.popen(cmd).read()[:-1])
+    print(subprocess.check_output(cmd).decode("UTF-8")[:-1])
 
 def cleanup(machine):
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + '" cleanup'
     print(cmd)
-    print(os.popen(cmd).read()[:-1])
+    print(subprocess.check_output(cmd).decode("UTF-8")[:-1])
     
     
 def profile(machine, shell="bash"):
     cmd = 'wsl.exe -d ' + str(machine) + ' "' + str(pat_con(script)) + '" profile ' + shell
-    return os.popen(cmd).read()
+    return subprocess.check_output(cmd).decode("UTF-8")
+


### PR DESCRIPTION
I use GWSL.
And, I got error.

~~~console
2021-12-07 00:57:32,949 - GWSL 1.4.0 - ERROR - Exception occurred - Error in Mainloop
Traceback (most recent call last):
  File "manager.py", line 4451, in <module>
  File "manager.py", line 4061, in draw
  File "manager.py", line 4014, in apper
  File "manager.py", line 2266, in app_launcher
  File "manager.py", line 2805, in spawn_n_run
  File "wsl_tools.py", line 191, in profile
UnicodeDecodeError: 'cp932' codec can't decode byte 0x86 in position 586: illegal multibyte sequence
~~~

I research.

I found the cause of this error to be the following.

In Japanese Windows, the default system character set is cp932 (Shift_JIS).
Therefore, Python also basically tries to handle strings as cp932.
However, in GNU/Linux, the character encoding of files is basically ASCII or UTF-8.
At least, it will be more than cp932.
Therefore, when reading `.profile', it is better to expect UTF-8 and read it with a higher success rate.
Therefore, I basically rewrote the wsl.exe process to assume that the return value of the process is UTF-8 and decode it.