### PR TITLE
fix: don't load module-waveout twice

### DIFF
--- a/PULSE/etc/pulse/default.pa
+++ b/PULSE/etc/pulse/default.pa
@@ -44,7 +44,6 @@ load-module module-native-protocol-tcp auth-anonymous=1
  
 #load-module module-native-protocol-tcp port=4713 auth-ip-acl=172.16.0.0/12
 load-module module-esound-protocol-tcp port=4714 auth-ip-acl=172.16.0.0/12
-load-module module-waveout
 
 
 load-module module-waveout sink_name=output source_name=input record=0


### PR DESCRIPTION
the module-waveout module is currently loaded twice, and the first time without `record=0` which causes a crash (see https://github.com/aseering/wsl_gui_autoinstall/issues/8#issuecomment-304552350)